### PR TITLE
feat: Template improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4928,7 +4928,6 @@
 			"version": "3.0.0-alpha.2",
 			"resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.0.0-alpha.2.tgz",
 			"integrity": "sha512-yHpz1HujxBcMq8e4jrHkkowzrJwuVyssCB+DuA91kt6LC0eIMZsDZY9tEhhOq+TyOhI3nbyXaDKJG6y1qB0A5A==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.2",
 				"@react-aria/i18n": "^3.2.0",
@@ -5469,7 +5468,6 @@
 			"version": "3.0.0-alpha.3",
 			"resolved": "https://registry.npmjs.org/@react-spectrum/tabs/-/tabs-3.0.0-alpha.3.tgz",
 			"integrity": "sha512-QRLLXReZ0/pSVOF6bXAg2JObouPUerzWQSvMTF5wCf6r7groEc2E8dqOABYIU2jyvD6U0cBWCzf3FFcClEFOCQ==",
-			"dev": true,
 			"requires": {
 				"@adobe/react-spectrum": "^3.6.0",
 				"@babel/runtime": "^7.6.2",
@@ -5748,7 +5746,6 @@
 			"version": "3.0.0-alpha.0",
 			"resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.0.0-alpha.0.tgz",
 			"integrity": "sha512-QJZ9N7DT89RkP18btvQhJvxWuv/JkSwtm14ftfk+5LBbzyxyLsD2KP6jDrNhXgmkRMmIyEaMt2w2VmI6fQ6UAA==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.2",
 				"@react-stately/list": "^3.2.2",
@@ -6031,7 +6028,6 @@
 			"version": "3.0.0-alpha.2",
 			"resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.0.0-alpha.2.tgz",
 			"integrity": "sha512-HQNS2plzuNhKPo88OGEW2Ja9aLeiWqgNqEemSxh0KAjkA8IsvDGaoQEpr9ZQIyBZ3PQIljvOpEJ/IwHU5LztrQ==",
-			"dev": true,
 			"requires": {
 				"@react-types/shared": "^3.2.1"
 			}
@@ -8111,6 +8107,7 @@
 			"version": "file:packages/telestion-client-template",
 			"requires": {
 				"@adobe/react-spectrum": "^3.6.0",
+				"@react-spectrum/tabs": "^3.0.0-alpha.3",
 				"@spectrum-icons/illustrations": "^3.2.0",
 				"@spectrum-icons/ui": "^3.2.0",
 				"@spectrum-icons/workflow": "^3.2.0",

--- a/packages/telestion-client-template/package.json
+++ b/packages/telestion-client-template/package.json
@@ -42,10 +42,10 @@
 	],
 	"dependencies": {
 		"@adobe/react-spectrum": "^3.6.0",
+		"@react-spectrum/tabs": "^3.0.0-alpha.3",
 		"@spectrum-icons/illustrations": "^3.2.0",
 		"@spectrum-icons/ui": "^3.2.0",
 		"@spectrum-icons/workflow": "^3.2.0",
-		"@react-spectrum/tabs": "^3.0.0-alpha.3",
 		"@wuespace/telestion-client-common": "file:../telestion-client-common",
 		"@wuespace/telestion-client-core": "file:../telestion-client-core",
 		"electron": "^11.2.1",
@@ -62,6 +62,7 @@
 		"@types/node": "^14.14.22",
 		"@types/react": "^17.0.0",
 		"@types/react-dom": "^17.0.0",
+		"@wuespace/telestion-client-cli": "file:../telestion-client-cli",
 		"@wuespace/telestion-client-types": "file:../telestion-client-types",
 		"react-scripts": "^4.0.1",
 		"typescript": "^4.1.3"

--- a/packages/telestion-client-template/template/.gitignore.ejs
+++ b/packages/telestion-client-template/template/.gitignore.ejs
@@ -39,3 +39,6 @@ docs
 # cypress test results
 cypress/videos
 cypress/screenshots
+
+# eslint cache
+.eslintcache

--- a/packages/telestion-client-template/template/package.json.ejs
+++ b/packages/telestion-client-template/template/package.json.ejs
@@ -1,8 +1,13 @@
 {
 	"name": "<%- moduleName %>",
 	"version": "0.0.0",
+	"scripts": {
+		"start": "tc-cli start",
+		"build": "tc-cli build",
+		"stats": "tc-cli stats"
+	},
 	"private": true,
-	"description": "",
+	"description": "<%- moduleName %>, a Telestion PSC generated using the telestion-client-cli",
 	"dependencies": <%- dependencies %>,
 	"devDependencies": <%- devDependencies %>
 }


### PR DESCRIPTION
Various small improvements for the template.

This also aligns the template's behavior with the documentation, 
where, under "Running the PSC during development", it states:

Run npm start
This runs tc-cli start. You can, instead, also run that 
command directly, allowing you to specify further options.

With this commit, the template gets aligned to that behavior.

I will, simaltaniously, add the changes to the already existing D2 PSC Repo.