### PR TITLE
feat(cli)!: Add `tc-cli generate widget` command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4928,7 +4928,6 @@
 			"version": "3.0.0-alpha.2",
 			"resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.0.0-alpha.2.tgz",
 			"integrity": "sha512-yHpz1HujxBcMq8e4jrHkkowzrJwuVyssCB+DuA91kt6LC0eIMZsDZY9tEhhOq+TyOhI3nbyXaDKJG6y1qB0A5A==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.2",
 				"@react-aria/i18n": "^3.2.0",
@@ -5469,7 +5468,6 @@
 			"version": "3.0.0-alpha.3",
 			"resolved": "https://registry.npmjs.org/@react-spectrum/tabs/-/tabs-3.0.0-alpha.3.tgz",
 			"integrity": "sha512-QRLLXReZ0/pSVOF6bXAg2JObouPUerzWQSvMTF5wCf6r7groEc2E8dqOABYIU2jyvD6U0cBWCzf3FFcClEFOCQ==",
-			"dev": true,
 			"requires": {
 				"@adobe/react-spectrum": "^3.6.0",
 				"@babel/runtime": "^7.6.2",
@@ -5748,7 +5746,6 @@
 			"version": "3.0.0-alpha.0",
 			"resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.0.0-alpha.0.tgz",
 			"integrity": "sha512-QJZ9N7DT89RkP18btvQhJvxWuv/JkSwtm14ftfk+5LBbzyxyLsD2KP6jDrNhXgmkRMmIyEaMt2w2VmI6fQ6UAA==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.2",
 				"@react-stately/list": "^3.2.2",
@@ -6031,7 +6028,6 @@
 			"version": "3.0.0-alpha.2",
 			"resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.0.0-alpha.2.tgz",
 			"integrity": "sha512-HQNS2plzuNhKPo88OGEW2Ja9aLeiWqgNqEemSxh0KAjkA8IsvDGaoQEpr9ZQIyBZ3PQIljvOpEJ/IwHU5LztrQ==",
-			"dev": true,
 			"requires": {
 				"@react-types/shared": "^3.2.1"
 			}
@@ -8064,6 +8060,7 @@
 				"@fliegwerk/logsemts": "^0.4.0-0",
 				"@wuespace/telestion-client-template": "file:packages/telestion-client-template",
 				"chalk": "^4.1.0",
+				"change-case": "^4.1.2",
 				"clui": "^0.3.6",
 				"debug": "^4.3.1",
 				"directory-tree": "^2.2.5",
@@ -8111,6 +8108,7 @@
 			"version": "file:packages/telestion-client-template",
 			"requires": {
 				"@adobe/react-spectrum": "^3.6.0",
+				"@react-spectrum/tabs": "^3.0.0-alpha.3",
 				"@spectrum-icons/illustrations": "^3.2.0",
 				"@spectrum-icons/ui": "^3.2.0",
 				"@spectrum-icons/workflow": "^3.2.0",
@@ -9866,7 +9864,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
 			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"dev": true,
 			"requires": {
 				"pascal-case": "^3.1.2",
 				"tslib": "^2.0.3"
@@ -9875,8 +9872,7 @@
 				"tslib": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-					"dev": true
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -9920,6 +9916,23 @@
 			"integrity": "sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg==",
 			"dev": true
 		},
+		"capital-case": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+				}
+			}
+		},
 		"capture-exit": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -9954,6 +9967,32 @@
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
+			}
+		},
+		"change-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+			"requires": {
+				"camel-case": "^4.1.2",
+				"capital-case": "^1.0.4",
+				"constant-case": "^3.0.4",
+				"dot-case": "^3.0.4",
+				"header-case": "^2.0.4",
+				"no-case": "^3.0.4",
+				"param-case": "^3.0.4",
+				"pascal-case": "^3.1.2",
+				"path-case": "^3.0.4",
+				"sentence-case": "^3.0.4",
+				"snake-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+				}
 			}
 		},
 		"char-regex": {
@@ -10591,6 +10630,23 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"dev": true
+		},
+		"constant-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case": "^2.0.2"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+				}
+			}
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -12190,7 +12246,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
 			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -12199,8 +12254,7 @@
 				"tslib": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-					"dev": true
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -15923,6 +15977,22 @@
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
 		},
+		"header-case": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+			"requires": {
+				"capital-case": "^1.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+				}
+			}
+		},
 		"hex-color-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
@@ -18628,7 +18698,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
 			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"dev": true,
 			"requires": {
 				"tslib": "^2.0.3"
 			},
@@ -18636,8 +18705,7 @@
 				"tslib": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-					"dev": true
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -19557,7 +19625,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
 			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"dev": true,
 			"requires": {
 				"lower-case": "^2.0.2",
 				"tslib": "^2.0.3"
@@ -19566,8 +19633,7 @@
 				"tslib": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-					"dev": true
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -20766,7 +20832,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
 			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"dev": true,
 			"requires": {
 				"dot-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -20775,8 +20840,7 @@
 				"tslib": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-					"dev": true
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -20870,7 +20934,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
 			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -20879,8 +20942,7 @@
 				"tslib": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-					"dev": true
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -20893,6 +20955,22 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
 			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+		},
+		"path-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+			"requires": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+				}
+			}
 		},
 		"path-dirname": {
 			"version": "1.0.2",
@@ -24690,6 +24768,23 @@
 				}
 			}
 		},
+		"sentence-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+				}
+			}
+		},
 		"serialize-error": {
 			"version": "7.0.1",
 			"resolved": "http://localhost:4873/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -24966,6 +25061,22 @@
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
 			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
 			"dev": true
+		},
+		"snake-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+			"requires": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+				}
+			}
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -26804,6 +26915,36 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+		},
+		"upper-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+			"requires": {
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+				}
+			}
+		},
+		"upper-case-first": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+			"requires": {
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+				}
+			}
 		},
 		"uri-js": {
 			"version": "4.4.0",

--- a/packages/telestion-client-cli/package.json
+++ b/packages/telestion-client-cli/package.json
@@ -54,6 +54,7 @@
 		"@fliegwerk/logsemts": "^0.4.0-0",
 		"@wuespace/telestion-client-template": "file:../telestion-client-template",
 		"chalk": "^4.1.0",
+		"change-case": "^4.1.2",
 		"clui": "^0.3.6",
 		"debug": "^4.3.1",
 		"directory-tree": "^2.2.5",

--- a/packages/telestion-client-cli/src/commands/generate.js
+++ b/packages/telestion-client-cli/src/commands/generate.js
@@ -1,19 +1,19 @@
 const debug = require('debug')('generate');
 const logger = require('../lib/logger')('generate');
+const fs = require('fs');
+const path = require('path');
 
 // yargs def
-const command = ['generate <component> [name]', 'g'];
+const command = ['generate <component> <name>', 'g'];
 const desc = 'Adds a new component to an existing Telestion Frontend Project';
 
 function builder(yargs) {
 	return yargs
-		.option('component', {
-			alias: 'c',
+		.positional('component', {
 			describe: 'The component type to add',
 			type: 'string'
 		})
-		.option('name', {
-			alias: 'n',
+		.positional('name', {
 			describe: 'The new component name',
 			type: 'string'
 		});
@@ -24,8 +24,83 @@ async function handler(argv) {
 	debug('Arguments:', argv);
 
 	// for implementation examples, look at the @server-state/cli refactoring branch
-	logger.error('Not implemented');
-	process.exit(1);
+	if (argv['component'] === 'widget' || argv['component'] === 'w') {
+		const widgetsFolder = path.join(process.cwd(), 'src', 'widgets');
+		if (
+			!fs.existsSync(widgetsFolder) ||
+			!fs.lstatSync(widgetsFolder).isDirectory()
+		) {
+			logger.error('It looks like your not inside a Telestion PSC Folder.');
+			logger.info("Expected to find folder ./src/widgets, but couldn't.");
+			logger.info('Please re-run this command inside a PSC directory.');
+			process.exit(1);
+		}
+
+		const safeName = argv['name'].toLowerCase().split(' ').join('_');
+		const widgetFolder = path.join(widgetsFolder, safeName);
+		fs.mkdirSync(widgetFolder);
+
+		fs.writeFileSync(
+			path.join(widgetFolder, 'index.ts'),
+			`import { Widget } from "@wuespace/telestion-client-types";
+import { Widget as WidgetRenderer } from "./widget";
+
+export const widget: Widget = {
+\tname: '${safeName}',
+\tWidget: WidgetRenderer
+};
+`
+		);
+		fs.writeFileSync(
+			path.join(widgetFolder, 'widget.tsx'),
+			`import { Heading } from '@adobe/react-spectrum';
+
+export function Widget() {
+\treturn <Heading level={2}>${safeName} widget</Heading>;
+}
+`
+		);
+
+		let overallIndexFile = path.join(widgetsFolder, 'index.ts');
+		const initialIndexTS = fs
+			.readFileSync(overallIndexFile, 'utf8')
+			.toString()
+			.split('\r\n')
+			.join('\n')
+			.split('\n');
+
+		const importIndex = initialIndexTS.findIndex(line =>
+			/^\s*\/\/ IMPORT_INSERT_MARK$/.exec(line)
+		);
+		initialIndexTS.splice(
+			importIndex,
+			1,
+			initialIndexTS[importIndex].replace(
+				'// IMPORT_INSERT_MARK',
+				`import { widget as ${safeName} } from './${safeName}';`
+			),
+			initialIndexTS[importIndex]
+		);
+
+		const arrayIndex = initialIndexTS.findIndex(line =>
+			/^\s*\/\/ ARRAY_FIRST_ELEMENT_INSERT_MARK$/.exec(line)
+		);
+
+		initialIndexTS.splice(
+			arrayIndex,
+			1,
+			initialIndexTS[arrayIndex],
+			initialIndexTS[arrayIndex].replace(
+				'// ARRAY_FIRST_ELEMENT_INSERT_MARK',
+				`${safeName},`
+			)
+		);
+
+		fs.writeFileSync(overallIndexFile, initialIndexTS.join('\n'));
+	} else {
+		logger.error('Invalid component type. Can only generate "widget".');
+		process.exit(1);
+	}
 }
 
 module.exports = {

--- a/packages/telestion-client-cli/src/commands/generate.js
+++ b/packages/telestion-client-cli/src/commands/generate.js
@@ -1,7 +1,6 @@
 const debug = require('debug')('generate');
 const logger = require('../lib/logger')('generate');
-const fs = require('fs');
-const path = require('path');
+const generateWidget = require('../lib/generate/widget');
 
 // yargs def
 const command = ['generate <component> <name>', 'g'];
@@ -25,78 +24,7 @@ async function handler(argv) {
 
 	// for implementation examples, look at the @server-state/cli refactoring branch
 	if (argv['component'] === 'widget' || argv['component'] === 'w') {
-		const widgetsFolder = path.join(process.cwd(), 'src', 'widgets');
-		if (
-			!fs.existsSync(widgetsFolder) ||
-			!fs.lstatSync(widgetsFolder).isDirectory()
-		) {
-			logger.error('It looks like your not inside a Telestion PSC Folder.');
-			logger.info("Expected to find folder ./src/widgets, but couldn't.");
-			logger.info('Please re-run this command inside a PSC directory.');
-			process.exit(1);
-		}
-
-		const safeName = argv['name'].toLowerCase().split(' ').join('_');
-		const widgetFolder = path.join(widgetsFolder, safeName);
-		fs.mkdirSync(widgetFolder);
-
-		fs.writeFileSync(
-			path.join(widgetFolder, 'index.ts'),
-			`import { Widget } from "@wuespace/telestion-client-types";
-import { Widget as WidgetRenderer } from "./widget";
-
-export const widget: Widget = {
-\tname: '${safeName}',
-\tWidget: WidgetRenderer
-};
-`
-		);
-		fs.writeFileSync(
-			path.join(widgetFolder, 'widget.tsx'),
-			`import { Heading } from '@adobe/react-spectrum';
-
-export function Widget() {
-\treturn <Heading level={2}>${safeName} widget</Heading>;
-}
-`
-		);
-
-		let overallIndexFile = path.join(widgetsFolder, 'index.ts');
-		const initialIndexTS = fs
-			.readFileSync(overallIndexFile, 'utf8')
-			.toString()
-			.split('\r\n')
-			.join('\n')
-			.split('\n');
-
-		const importIndex = initialIndexTS.findIndex(line =>
-			/^\s*\/\/ IMPORT_INSERT_MARK$/.exec(line)
-		);
-		initialIndexTS.splice(
-			importIndex,
-			1,
-			initialIndexTS[importIndex].replace(
-				'// IMPORT_INSERT_MARK',
-				`import { widget as ${safeName} } from './${safeName}';`
-			),
-			initialIndexTS[importIndex]
-		);
-
-		const arrayIndex = initialIndexTS.findIndex(line =>
-			/^\s*\/\/ ARRAY_FIRST_ELEMENT_INSERT_MARK$/.exec(line)
-		);
-
-		initialIndexTS.splice(
-			arrayIndex,
-			1,
-			initialIndexTS[arrayIndex],
-			initialIndexTS[arrayIndex].replace(
-				'// ARRAY_FIRST_ELEMENT_INSERT_MARK',
-				`${safeName},`
-			)
-		);
-
-		fs.writeFileSync(overallIndexFile, initialIndexTS.join('\n'));
+		generateWidget(argv);
 	} else {
 		logger.error('Invalid component type. Can only generate "widget".');
 		process.exit(1);

--- a/packages/telestion-client-cli/src/lib/generate/widget/createWidgetIndexTS.js
+++ b/packages/telestion-client-cli/src/lib/generate/widget/createWidgetIndexTS.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * @param {string} widgetFolder
+ * @param {string} safeName
+ */
+function createWidgetIndexTS(widgetFolder, safeName) {
+	fs.writeFileSync(
+		path.join(widgetFolder, 'index.ts'),
+		`import { Widget } from "@wuespace/telestion-client-types";
+import { Widget as WidgetRenderer } from "./widget";
+
+export const widget: Widget = {
+\tname: '${safeName}',
+\tWidget: WidgetRenderer
+};
+`
+	);
+}
+
+module.exports = createWidgetIndexTS;

--- a/packages/telestion-client-cli/src/lib/generate/widget/createWidgetTSX.js
+++ b/packages/telestion-client-cli/src/lib/generate/widget/createWidgetTSX.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * @param {string} widgetFolder
+ * @param {string} safeName
+ */
+function createWidgetTSX(widgetFolder, safeName) {
+	fs.writeFileSync(
+		path.join(widgetFolder, 'widget.tsx'),
+		`import { Heading } from '@adobe/react-spectrum';
+
+export function Widget() {
+\treturn <Heading level={2}>${safeName} widget</Heading>;
+}
+`
+	);
+}
+
+module.exports = createWidgetTSX;

--- a/packages/telestion-client-cli/src/lib/generate/widget/index.js
+++ b/packages/telestion-client-cli/src/lib/generate/widget/index.js
@@ -1,0 +1,42 @@
+const createWidgetTSX = require('./createWidgetTSX');
+const createWidgetIndexTS = require('./createWidgetIndexTS');
+
+const fs = require('fs');
+const path = require('path');
+const { INSERT_BELOW, INSERT_ABOVE, modifyFile } = require('../../modify-file');
+const logger = require('../lib/logger')('widget-generator');
+
+function generateWidget(argv) {
+	const widgetsFolder = path.join(process.cwd(), 'src', 'widgets');
+	if (
+		!fs.existsSync(widgetsFolder) ||
+		!fs.lstatSync(widgetsFolder).isDirectory()
+	) {
+		logger.error('It looks like your not inside a Telestion PSC Folder.');
+		logger.info("Expected to find folder ./src/widgets, but couldn't.");
+		logger.info('Please re-run this command inside a PSC directory.');
+		process.exit(1);
+	}
+
+	const safeName = argv['name'].toLowerCase().split(' ').join('_');
+	const widgetFolder = path.join(widgetsFolder, safeName);
+	fs.mkdirSync(widgetFolder);
+	createWidgetIndexTS(widgetFolder, safeName);
+	createWidgetTSX(widgetFolder, safeName);
+
+	let allWidgetsIndexFile = path.join(widgetsFolder, 'index.ts');
+	modifyFile(allWidgetsIndexFile, [
+		{
+			needle: '// IMPORT_INSERT_MARK',
+			position: INSERT_ABOVE,
+			text: `import { widget as ${safeName} } from './${safeName}';`
+		},
+		{
+			needle: '// ARRAY_FIRST_ELEMENT_INSERT_MARK',
+			position: INSERT_BELOW,
+			text: safeName + ','
+		}
+	]);
+}
+
+module.exports = generateWidget;

--- a/packages/telestion-client-cli/src/lib/generate/widget/index.js
+++ b/packages/telestion-client-cli/src/lib/generate/widget/index.js
@@ -3,6 +3,7 @@ const createWidgetIndexTS = require('./createWidgetIndexTS');
 
 const fs = require('fs');
 const path = require('path');
+const { camelCase, paramCase } = require('change-case');
 const { INSERT_BELOW, INSERT_ABOVE, modifyFile } = require('../../modify-file');
 const logger = require('../lib/logger')('widget-generator');
 
@@ -18,23 +19,24 @@ function generateWidget(argv) {
 		process.exit(1);
 	}
 
-	const safeName = argv['name'].toLowerCase().split(' ').join('_');
-	const widgetFolder = path.join(widgetsFolder, safeName);
+	const nameAsCamelCase = camelCase(argv['name']);
+	const folderName = paramCase(argv['name']);
+	const widgetFolder = path.join(widgetsFolder, folderName);
 	fs.mkdirSync(widgetFolder);
-	createWidgetIndexTS(widgetFolder, safeName);
-	createWidgetTSX(widgetFolder, safeName);
+	createWidgetIndexTS(widgetFolder, nameAsCamelCase);
+	createWidgetTSX(widgetFolder, nameAsCamelCase);
 
 	let allWidgetsIndexFile = path.join(widgetsFolder, 'index.ts');
 	modifyFile(allWidgetsIndexFile, [
 		{
 			needle: '// IMPORT_INSERT_MARK',
 			position: INSERT_ABOVE,
-			text: `import { widget as ${safeName} } from './${safeName}';`
+			text: `import { widget as ${nameAsCamelCase} } from './${folderName}';`
 		},
 		{
 			needle: '// ARRAY_FIRST_ELEMENT_INSERT_MARK',
 			position: INSERT_BELOW,
-			text: safeName + ','
+			text: nameAsCamelCase + ','
 		}
 	]);
 }

--- a/packages/telestion-client-cli/src/lib/generate/widget/index.js
+++ b/packages/telestion-client-cli/src/lib/generate/widget/index.js
@@ -39,6 +39,9 @@ function generateWidget(argv) {
 			text: nameAsCamelCase + ','
 		}
 	]);
+
+	logger.success(`Widget ${nameAsCamelCase} created successfully.`);
+	logger.info(`You can find it at ${widgetFolder}.`);
 }
 
 module.exports = generateWidget;

--- a/packages/telestion-client-cli/src/lib/modify-file.js
+++ b/packages/telestion-client-cli/src/lib/modify-file.js
@@ -42,10 +42,7 @@ function modifyFile(filePath, replacers) {
 		);
 
 		const newLines = [
-			lines[insertionMarkLineIndex].replace(
-				replacer.needle,
-				replacer.text
-			)
+			lines[insertionMarkLineIndex].replace(replacer.needle, replacer.text)
 		];
 
 		if (replacer.position === INSERT_ABOVE) {

--- a/packages/telestion-client-cli/src/lib/modify-file.js
+++ b/packages/telestion-client-cli/src/lib/modify-file.js
@@ -43,7 +43,7 @@ function modifyFile(filePath, replacers) {
 
 		const newLines = [
 			lines[insertionMarkLineIndex].replace(
-				'// IMPORT_INSERT_MARK',
+				replacer.needle,
 				replacer.text
 			)
 		];

--- a/packages/telestion-client-cli/src/lib/modify-file.js
+++ b/packages/telestion-client-cli/src/lib/modify-file.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+
+/**
+ * Insert in the line before the insertion mark
+ */
+const INSERT_ABOVE = Symbol('Insert in the line before the insertion mark');
+/**
+ * Insert in the line below the insertion mark
+ */
+const INSERT_BELOW = Symbol('Insert in the line below the insertion mark');
+/**
+ * Replace the line with the insertion mark
+ */
+const REPLACE = Symbol('Replace the line with the insertion mark');
+
+/**
+ * @typedef {Object} Replacer
+ * @property {string} needle - the string for which the file gets searched in the replacer.
+ * @property {string} text - the text that gets inserted above/below/instead of the `needle`, depending on the `position`
+ * @property {INSERT_ABOVE | INSERT_BELOW | REPLACE} position - the position where `text` gets inserted relative to the
+ * `needle`'s line.
+ */
+
+/**
+ * Modifies a file by replacing or inserting text above/below specific sections of code, identified as "needle".
+ *
+ * Processes first occurrence of each replacer, only!
+ * @param {string} filePath
+ * @param {Replacer[]} replacers
+ */
+function modifyFile(filePath, replacers) {
+	const lines = fs
+		.readFileSync(filePath, 'utf8')
+		.toString()
+		.split('\r\n')
+		.join('\n')
+		.split('\n');
+
+	for (let replacer of replacers) {
+		const insertionMarkLineIndex = lines.findIndex(line =>
+			line.includes(replacer.needle)
+		);
+
+		const newLines = [
+			lines[insertionMarkLineIndex].replace(
+				'// IMPORT_INSERT_MARK',
+				replacer.text
+			)
+		];
+
+		if (replacer.position === INSERT_ABOVE) {
+			newLines.push(lines[insertionMarkLineIndex]);
+		} else if (replacer.position === INSERT_BELOW) {
+			newLines.unshift(lines[insertionMarkLineIndex]);
+		} else if (replacer.position !== REPLACE) {
+			throw new Error(
+				'Internal Error: No valid position specified in replacer passed to modifyFile. ' +
+					'This is an internal error, and as a user, you should never get to see this. Somehow, somethings seems ' +
+					'to have mal-functioned. If you could report this (including the output) to the Telestion Team, ' +
+					'we would appreciate that a lot. Sorry, and thank you very much in advance.'
+			);
+		}
+
+		lines.splice(insertionMarkLineIndex, 1, ...newLines);
+	}
+	fs.writeFileSync(filePath, lines.join('\n'));
+}
+
+module.exports = { modifyFile, INSERT_ABOVE, INSERT_BELOW, REPLACE };

--- a/packages/telestion-client-template/template/src/widgets/index.ts.ejs
+++ b/packages/telestion-client-template/template/src/widgets/index.ts.ejs
@@ -1,6 +1,15 @@
+/*
+This file gets manipulated automatically using the tc-cli.
+
+Please do not remove the // XXX_IMPORT_MARK comments or you will loose the ability to generate widgets automatically
+using the tc-cli generate widget command.
+ */
+
 import { Widget } from "@wuespace/telestion-client-types";
 import { widget as sampleWidget } from "./sample-widget";
+// IMPORT_INSERT_MARK
 
-export const projectWidgets: Array<Widget> = [
+export const projectWidgets: Widget[] = [
+	// ARRAY_FIRST_ELEMENT_INSERT_MARK
 	sampleWidget
 ];


### PR DESCRIPTION
Refs: #263 
BREAKING CHANGE: For previously generated PSCs to work with the new CLI, the `// IMPORT_INSERT_MARK` and `// ARRAY_FIRST_ELEMENT_INSERT_MARK` comments have to retrospectively be placed below all imports and at the beginning of the `projectWidgets` array, respectively