### PR TITLE
feat(cli): Add `tc-cli stats` command implementation

### DIFF
--- a/packages/telestion-client-cli/src/commands/stats.js
+++ b/packages/telestion-client-cli/src/commands/stats.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
 const debug = require('debug')('stats');
 const logger = require('../lib/logger')('stats');
 
@@ -7,16 +10,100 @@ const desc =
 	'Displays some interesting stats around a Telestion Frontend project';
 
 function builder(yargs) {
-	return yargs;
+	return yargs.option('json', {
+		describe: 'Output the statistics as JSON',
+		alias: 'j',
+		default: false,
+		boolean: true
+	});
 }
 
 async function handler(argv) {
-	// gathering information
 	debug('Arguments:', argv);
 
-	// for implementation examples, look at the @server-state/cli refactoring branch
-	logger.error('Not implemented');
-	process.exit(1);
+	const projectPath = process.cwd();
+
+	const packageJSONPath = path.join(projectPath, 'package.json');
+	verifyCWDIsPSCProjectFolder(projectPath, argv);
+
+	const { name, version, dependencies } = JSON.parse(
+		fs.readFileSync(packageJSONPath).toString()
+	);
+	const widgets = getWidgets(projectPath);
+	reportStats({
+		json: argv['json'],
+		name,
+		version,
+		dependencies,
+		widgets,
+		projectPath
+	});
+}
+
+function verifyCWDIsPSCProjectFolder(projectPath, argv) {
+	const noPSCDirErrorMessage =
+		'Not called in a PSC directory. Expected to find package.json and ./src/widgets, but at least one was not found.';
+	if (
+		!fs.existsSync(path.join(projectPath, 'package.json')) ||
+		!fs.existsSync(path.join(projectPath, 'src', 'widgets'))
+	) {
+		if (argv.json) {
+			console.log(
+				JSON.stringify({
+					error: noPSCDirErrorMessage
+				})
+			);
+		} else {
+			logger.error(noPSCDirErrorMessage);
+			logger.info(
+				'Please try calling the command again inside a PSC directory'
+			);
+		}
+	}
+}
+
+function getWidgets(projectPath) {
+	return fs
+		.readdirSync(path.join(projectPath, 'src', 'widgets'))
+		.filter(
+			file =>
+				fs
+					.lstatSync(path.join(projectPath, 'src', 'widgets', file))
+					.isDirectory() && !file.startsWith('.')
+		);
+}
+
+function reportStats({
+	json,
+	name,
+	version,
+	dependencies,
+	widgets,
+	projectPath
+}) {
+	if (json) {
+		logger.info(
+			`Statistics for the Telestion PSC project ${name ?? 'Anonymous'} @ ${
+				version ?? 'Unknown version'
+			}`
+		);
+		logger.info('Dependencies:', Object.keys(dependencies).length);
+		logger.info(
+			'Widgets (',
+			widgets.length,
+			'):\n',
+			widgets
+				.map(s => `- ${s} (${path.join(projectPath, 'src', 'widgets', s)})`)
+				.join('\n')
+		);
+	} else {
+		console.log({
+			name,
+			version,
+			widgets,
+			dependencies: Object.keys(dependencies)
+		});
+	}
 }
 
 module.exports = {


### PR DESCRIPTION
Can output both human-readable and machine-parsable JSON statistics about a PSC project.

Refs: #263 