### PR TITLE
MERGE-BY-REBASE: fix(template)!: Add `eslintConfig` to PSC package.json

### DIFF
--- a/packages/telestion-client-template/template/package.json.ejs
+++ b/packages/telestion-client-template/template/package.json.ejs
@@ -11,6 +11,12 @@
 	},
 	"private": true,
 	"description": "<%- moduleName %>, a Telestion PSC generated using the telestion-client-cli",
+	"eslintConfig": {
+		"extends": [
+			"react-app",
+			"react-app/jest"
+		]
+	},
 	"dependencies": <%- dependencies %>,
 	"devDependencies": <%- devDependencies %>
 }


### PR DESCRIPTION
Closes: #305
BREAKING CHANGE: While, in and of itself, this doesn't constitute a breaking change, issues may arise in PSCs generated using the template before this change. This is why we want to bring special attention to it.

  To fix PSCs generated before with versions prior to this, add the following property to the PSC's `package.json`:

  ```json
  "eslintConfig": {
    "extends": [
      "react-app",
      "react-app/jest"
    ]
  }
  ```

  You won't have to do this steps for PSCs generated with the new version.