### PR TITLE
feat(common): Add keyboard controls to the `LoginForm` component

### DIFF
--- a/packages/telestion-client-common/src/components/pages/login-page/login-form/form/form.tsx
+++ b/packages/telestion-client-common/src/components/pages/login-page/login-form/form/form.tsx
@@ -49,11 +49,18 @@ export function Form({
 		}
 	}, [onSubmit, password, serverUrl, username]);
 
+	const [focused, setFocused] = useState(() => {
+		if (initialUsername) return 2;
+		if (initialServerURL) return 1;
+		return 0;
+	});
+
 	return (
 		<>
 			<RSForm maxWidth="100%" isRequired isDisabled={isLoading}>
 				<TextField
-					autoFocus
+					autoFocus={focused === 0}
+					onNext={() => setFocused(1)}
 					label="Backend Server"
 					placeholder="Server URL"
 					initialValue={initialServerURL}
@@ -61,6 +68,8 @@ export function Form({
 					validator={isValidHttpUrl}
 				/>
 				<TextField
+					autoFocus={focused === 1}
+					onNext={() => setFocused(2)}
 					label="Username"
 					placeholder="Your username"
 					initialValue={initialUsername}
@@ -68,6 +77,8 @@ export function Form({
 					validator={isValidText}
 				/>
 				<TextField
+					autoFocus={focused === 2}
+					onNext={login}
 					label="Password"
 					placeholder="Your password"
 					type="password"

--- a/packages/telestion-client-common/src/components/pages/login-page/login-form/form/text-field.tsx
+++ b/packages/telestion-client-common/src/components/pages/login-page/login-form/form/text-field.tsx
@@ -42,6 +42,12 @@ export type TextFieldProps = Omit<
 	 * @returns the validation state of the tested content
 	 */
 	validator?: (text: string) => ValidationState;
+
+	/**
+	 * Gets called when the user presses the enter key in the text field
+	 * with a valid value
+	 */
+	onNext?: () => void;
 };
 
 /**
@@ -74,6 +80,7 @@ export function TextField({
 	initialValue = '',
 	onChange,
 	validator,
+	onNext,
 	...textFieldProps
 }: TextFieldProps) {
 	const [value, setValue] = useState(initialValue);
@@ -97,6 +104,9 @@ export function TextField({
 	return (
 		<SpectrumTextField
 			value={value}
+			onKeyUp={e =>
+				e.key === 'Enter' && isValid === 'valid' && onNext && onNext()
+			}
 			onChange={setValue}
 			validationState={isValid}
 			{...textFieldProps}

--- a/packages/telestion-client-common/src/components/pages/login-page/login-form/form/text-field.tsx
+++ b/packages/telestion-client-common/src/components/pages/login-page/login-form/form/text-field.tsx
@@ -45,7 +45,7 @@ export type TextFieldProps = Omit<
 
 	/**
 	 * Gets called when the user presses the enter key in the text field
-	 * with a valid value
+	 * with a valid value.
 	 */
 	onNext?: () => void;
 };


### PR DESCRIPTION
When pressing the return key, focus will jump to the next input, or, on the last input, the login will get triggered

Closes: #364