### PR TITLE
REBASE: chore(ci): Fix workflows 

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,11 +1,13 @@
 # Workflow name
 name: 'Chromatic'
 
-# Event for the workflow
+# Events that trigger this workflow
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   chromatic-deployment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 
+# Events that trigger this workflow
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,34 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  lint:
+    name: Lint source code
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - name: Checkout 📥
+        uses: actions/checkout@v2.3.4
+      - name: Setup Node 💿
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 14
+
+      - name: Restore npm cache ♻️
+        uses: actions/cache@v2.1.4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install development dependencies 📚
+        run: npm ci
+      - name: Check code style 📑
+        run: npm run style:ci
+      - name: Run Linter 📑
+        run: npm run lint
+
   build:
     name: Build all packages
     runs-on: ubuntu-latest

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,4 +1,6 @@
 name: Code Analysis
+
+# Events that trigger this workflow
 on:
   push:
     branches: [main]

--- a/.github/workflows/code-climate.yml
+++ b/.github/workflows/code-climate.yml
@@ -1,13 +1,16 @@
-name: Docs
+name: Code Climate
 
 # Events that trigger this workflow
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
-  build-and-deploy:
-    name: Build and deploy documentation
+  code-climate-report:
+    name: Report code coverage to code climate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 📥
@@ -27,14 +30,10 @@ jobs:
 
       - name: Install development dependencies 📚
         run: npm ci
-      - name: Build documentation 🛠️
-        run: npm run docs:ci
-      - name: Finalize build 🪄
-        run: touch docs/.nojekyll
 
-      - name: Deploy documentation 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.0
+      - name: Generate and publish code coverage to code climate 📠
+        uses: paambaati/codeclimate-action@v2.7.5
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
         with:
-          branch: gh-pages
-          folder: docs
-          clean: true
+          coverageCommand: npm run test:unit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,13 @@
 
 name: Lint
 
-on: push
+# Events that trigger this workflow
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   run-linters:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 
+# Events that trigger this workflow
 on: workflow_dispatch
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: Test and Coverage
 
+# Events that trigger this workflow
 on: [push, pull_request]
 
 jobs:
@@ -29,35 +30,6 @@ jobs:
         run: npm run build:all
       - name: Run unit tests and generate coverage 🛃
         run: npm run test
-
-  code-climate-report:
-    name: Report code coverage to code climate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout 📥
-        uses: actions/checkout@v2.3.4
-      - name: Setup Node 💿
-        uses: actions/setup-node@v2.1.5
-        with:
-          node-version: 14
-
-      - name: Restore npm cache ♻️
-        uses: actions/cache@v2.1.4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install development dependencies 📚
-        run: npm ci
-
-      - name: Generate and publish code coverage to code climate 📠
-        uses: paambaati/codeclimate-action@v2.7.5
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
-        with:
-          coverageCommand: npm run test:unit
 
   cli-e2e-test:
     name: CLI E2E Test


### PR DESCRIPTION
## Features

Fix workflows so that external contributors can submit changes without repository secrets.

Please see: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

## Notes

After consulting @pklaschka, we **changed triggers** for workflows that use repository secrets so that external contributers can successfully submit their changes.
Further all actions, that are important for the repository state and **require secrets**, can be triggered via a **workflow dispatch event** in the "Actions" tab. (to not lose the ability to check external PRs)