### PR TITLE
REBASE: chore(deps): Security fix for xmldom dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28955,14 +28955,14 @@
 			}
 		},
 		"node_modules/plist": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-			"integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+			"integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
 			"optional": true,
 			"dependencies": {
-				"base64-js": "^1.2.3",
+				"base64-js": "^1.5.1",
 				"xmlbuilder": "^9.0.7",
-				"xmldom": "0.1.x"
+				"xmldom": "^0.5.0"
 			},
 			"engines": {
 				"node": ">=6"
@@ -43720,13 +43720,12 @@
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
 		},
 		"node_modules/xmldom": {
-			"version": "0.1.31",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-			"deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+			"integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
 			"optional": true,
 			"engines": {
-				"node": ">=0.1"
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/xtend": {
@@ -66946,14 +66945,14 @@
 			}
 		},
 		"plist": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-			"integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+			"integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
 			"optional": true,
 			"requires": {
-				"base64-js": "^1.2.3",
+				"base64-js": "^1.5.1",
 				"xmlbuilder": "^9.0.7",
-				"xmldom": "0.1.x"
+				"xmldom": "^0.5.0"
 			},
 			"dependencies": {
 				"xmlbuilder": {
@@ -78299,9 +78298,9 @@
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
 		},
 		"xmldom": {
-			"version": "0.1.31",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+			"integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
 			"optional": true
 		},
 		"xtend": {


### PR DESCRIPTION
# npm audit report

**xmldom**  <0.5.0
**Misinterpretation of malicious XML input** - https://npmjs.com/advisories/1650
fix available via `npm audit fix`
node_modules/xmldom
  **plist**  0.3.2 - 3.0.1
  Depends on vulnerable versions of xmldom
  node_modules/plist